### PR TITLE
Update synthetic_mzml.py

### DIFF
--- a/smiter/synthetic_mzml.py
+++ b/smiter/synthetic_mzml.py
@@ -475,7 +475,7 @@ def write_scans(
                                 "MSn Spectrum",
                                 {"ms level": 2},
                                 {
-                                    "scan start time": scan.retention_time,
+                                    "scan start time": prod.retention_time,
                                     "unitName": "second",
                                 },
                                 {"total ion current": sum(prod.i)},


### PR DESCRIPTION
- Fix bug where RT of precursor scan instead of product scan was written in `write_scans`